### PR TITLE
Move "About" To Mission

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,7 +2,7 @@
   url: "/"
   side: left
 
-- title: About
+- title: Mission
   url: "/info/"
   side: left
   


### PR DESCRIPTION
The About page linkes to the OSIP mission statement. Since it's next to the aims in the navigation bar, "Mission" is a more suitable name